### PR TITLE
Remove unreachable case for err != nil

### DIFF
--- a/internal/sdp/unmarshal.go
+++ b/internal/sdp/unmarshal.go
@@ -65,7 +65,6 @@ func (s *SessionDescription) Unmarshal(raw string) output.Message { //nolint:cyc
 	// s=
 	key, value, scanStatus, msg = scanner.nextLine()
 	switch {
-	case err != nil:
 	case msg.Message != "":
 		return msg
 	case !scanStatus:


### PR DESCRIPTION
#### Description

This case "case err != nil:" is impossible, This PR removes it. 