### PR TITLE
Update lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,9 +131,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
         - forbidigo
+        - gocognit
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands


### PR DESCRIPTION
#### Description

Update lint rules to forbid the use of direct testing.T helpers.

pion/.goassets/pull/222

#### Reference issue

N/A
